### PR TITLE
Build caproto v0.3.1

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -13,7 +13,7 @@ jobs:
       linux_:
         CONFIG: linux_
         UPLOAD_PACKAGES: True
-        UPLOAD_ON_BRANCH: master
+        UPLOAD_ON_BRANCH: v0.3.x
         DOCKER_IMAGE: condaforge/linux-anvil-comp7
   steps:
   # configure qemu binfmt-misc running.  This allows us to run docker containers

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 About caproto
 =============
 
-Home: http://github.com/nsls-ii/caproto
+Home: http://github.com/caproto/caproto
 
 Package license: BSD-3-Clause
 
@@ -80,5 +80,4 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
-* [@CJ-Wright](https://github.com/CJ-Wright/)
 

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -13,4 +13,4 @@ provider:
   linux: azure
   osx: azure
   win: azure
-upload_on_branch: master
+upload_on_branch: v0.3.x

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,14 @@
 {% set name = "caproto" %}
-{% set version = "0.4.0" %}
+{% set version = "0.3.0" %}
+{% set sha256 = "342d5369fc388435f4373dc9bc92d1d351f6f384d18f130a8dbde1bee374c693" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://github.com/nsls-ii/{{ name }}/archive/v{{ version }}.tar.gz
-  sha256: 61f28af8846ad10645837f6de4438ae6c82c36cecabbd64a353ec3b6a723a8e3
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
 
 build:
   noarch: python
@@ -37,14 +38,14 @@ requirements:
 test:
   imports:
     - {{ name }}
+  commands:
+    - {{ name}}-get -h
+    - {{ name}}-get --help
+    - {{ name}}-put --help
 
 about:
-  home: http://github.com/nsls-ii/caproto
+  home: http://github.com/caproto/caproto
   license: BSD-3-Clause
   license_family: BSD
   license_file: '{{ environ["RECIPE_DIR"] }}/LICENSE'
   summary: 'a bring-your-own-IO implementation of the EPICS Channel Access protocol in pure Python'
-
-extra:
-  recipe-maintainers:
-    - CJ-Wright

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "caproto" %}
-{% set version = "0.3.0" %}
-{% set sha256 = "342d5369fc388435f4373dc9bc92d1d351f6f384d18f130a8dbde1bee374c693" %}
+{% set version = "0.3.1" %}
+{% set sha256 = "17651ea8559a1759dab23ece8e607fe5050d1d49ba7e229469f698f9ef141efb" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
From https://pypi.org/project/caproto/0.3.1/#files.