### PR TITLE
Build caproto v0.3.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "caproto" %}
-{% set version = "0.3.3" %}
-{% set sha256 = "9d38df8123567dc088c04bb4c31a74f7c184adff5c429476c16aab98aaff94ec" %}
+{% set version = "0.3.4" %}
+{% set sha256 = "6d6ceacfab999444ea911410f88226f9d71a0c5792ec7c4216567ed95b5cf70f" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
Based on https://pypi.org/project/caproto/0.3.4/#files.